### PR TITLE
VIRTS-1952: Changing Link IDs to UUID

### DIFF
--- a/app/gameboard_svc.py
+++ b/app/gameboard_svc.py
@@ -63,7 +63,7 @@ class GameboardService(BaseService):
         operations = await self.get_service('data_svc').locate('operations')
         for op in operations:
             for link in op.chain:
-                if str(link_id) == link.unique:
+                if link_id == link.id:
                     return op, link
         return None, None
 


### PR DESCRIPTION
## Description

Change Link IDs to use UUIDs instead of integers.

See: https://github.com/mitre/caldera/pull/2092

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Log in as red
- Run "Discovery" adversary
- Open Gameboard
- Select operation
- Note PID for "View admin shares" (first ability)
- Click "Add external detection", enter:
  - tactic: discovery
  - technique: T1135 | Network Share Discovery
  - pid: PID from gameboard
- See something like: "Detection successfully added for link in operation: test - 2021-03-23 18:32:52.110373."

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works